### PR TITLE
Add ESP32 MQTT setup updates and example config

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,15 @@
+name: Dev
+
+on:
+  pull_request:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build example.yaml
+        uses: esphome/build-action@v7
+        with:
+          yaml-file: example.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,18 @@
 *.exe
 *.out
 *.app
+
+# ESPHome / local build artifacts
+.esphome/
+
+# Python virtualenvs
+.venv/
+.venv*/
+venv/
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# macOS
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ __pycache__/
 .DS_Store
 
 # other
-/.agnet-shell/
+/.agent-shell/
+settings.local.json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/hzkincony/esphome-tuya-iot
-      ref: v1.2.0
+      ref: v1.2.2
 
 esp32:
   board: esp32dev

--- a/components/tuya_iot/__init__.py
+++ b/components/tuya_iot/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome import automation
+from esphome.components import esp32
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -10,6 +11,7 @@ from esphome.const import (
     CONF_QOS,
     CONF_PAYLOAD,
 )
+from esphome.core import CORE
 
 DEPENDENCIES = ["network", "time"]
 AUTO_LOAD = ["json"]
@@ -71,6 +73,11 @@ CONFIG_SCHEMA = cv.Schema({
 }).extend(cv.COMPONENT_SCHEMA)
 
 def to_code(config):
+    if CORE.is_esp32:
+        # ESPHome 2026+ excludes some IDF components by default for Arduino builds.
+        # This component directly includes mqtt_client.h, so keep mqtt enabled.
+        esp32.include_builtin_idf_component("mqtt")
+
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     timeComponent = yield cg.get_variable(config["time_id"])
@@ -79,7 +86,6 @@ def to_code(config):
     cg.add(var.set_device_id(config["device_id"]))
     cg.add(var.set_device_secret(config["device_secret"]))
     cg.add(var.set_region_domain(config["region"]))
-    cg.add_library("daknuett/cryptosuite2", "0.2.7")
 
     for conf in config.get(CONF_ON_MESSAGE, []):
         trig = cg.new_Pvariable(conf[CONF_TRIGGER_ID], conf[CONF_TOPIC])

--- a/components/tuya_iot/tuya_iot_component.cpp
+++ b/components/tuya_iot/tuya_iot_component.cpp
@@ -1,10 +1,40 @@
 #include "tuya_iot_component.h"
 #include "esphome/components/network/util.h"
-#include "sha/sha256.h"
+#include <esp_idf_version.h>
+#include <mbedtls/md.h>
+#include <cstring>
 #include <string>
 
 namespace esphome {
   namespace tuya_iot {
+    static bool hmac_sha256_hex(const char *key, const char *content, std::string &out) {
+      if (key == nullptr || content == nullptr) {
+        return false;
+      }
+      const auto *md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+      if (md_info == nullptr) {
+        return false;
+      }
+      unsigned char digest[32];
+      int ret = mbedtls_md_hmac(md_info,
+                                reinterpret_cast<const unsigned char *>(key),
+                                strlen(key),
+                                reinterpret_cast<const unsigned char *>(content),
+                                strlen(content),
+                                digest);
+      if (ret != 0) {
+        return false;
+      }
+      static const char hex[] = "0123456789abcdef";
+      out.clear();
+      out.reserve(sizeof(digest) * 2);
+      for (unsigned char byte : digest) {
+        out.push_back(hex[(byte >> 4) & 0x0F]);
+        out.push_back(hex[byte & 0x0F]);
+      }
+      return true;
+    }
+
     const char tuya_cacert_pem[] = {\
       "-----BEGIN CERTIFICATE-----\n"\
       "MIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\n"\
@@ -278,37 +308,47 @@ namespace esphome {
         char content[200];
         sprintf(content, "deviceId=%s,timestamp=%d,secureMode=1,accessType=1", device_id_, now);
         ESP_LOGD(TAG, "content: %s", content);
-        Sha256.initHmac((uint8_t * ) device_secret_, 16);
-        Sha256.print(content);
-        uint8_t * result = Sha256.resultHmac();
-        std::string password("");
-        for (int i = 0; i < 32; i++) {
-          password = password.append(1, "0123456789abcdef"[result[i] >> 4]);
-          password = password.append(1, "0123456789abcdef"[result[i] & 0xf]);
+        std::string password;
+        if (!hmac_sha256_hex(device_secret_, content, password)) {
+          ESP_LOGD(TAG, "Failed to calculate HMAC-SHA256");
+          return;
         }
 
-        char username[200];
+        static char username[200];
         sprintf(username, "%s|signMethod=hmacSha256,timestamp=%d,secureMode=1,accessType=1", device_id_, now);
-        mqtt_cfg_.username = username;
-        ESP_LOGD(TAG, "username: %s", mqtt_cfg_.username);
+        ESP_LOGD(TAG, "username: %s", username);
 
-        char* password_str = new char[254];
-        password_str[password.copy(password_str, password.size(), 0)] = '\0';
-        mqtt_cfg_.password = password_str;
-        ESP_LOGD(TAG, "password: %s", mqtt_cfg_.password);
+        static char password_str[65];
+        snprintf(password_str, sizeof(password_str), "%s", password.c_str());
+        ESP_LOGD(TAG, "password: %s", password_str);
 
         static char uri[50];
         sprintf(uri, "mqtts://%s:8883", region_domain_);
+        static char client_id[50];
+        sprintf(client_id, "tuyalink_%s", device_id_);
+
+#if ESP_IDF_VERSION_MAJOR >= 5
+        mqtt_cfg_.credentials.username = username;
+        mqtt_cfg_.credentials.authentication.password = password_str;
+        mqtt_cfg_.broker.address.uri = uri;
+        mqtt_cfg_.broker.verification.certificate = tuya_cacert_pem;
+        mqtt_cfg_.broker.verification.certificate_len = sizeof(tuya_cacert_pem);
+        mqtt_cfg_.broker.verification.skip_cert_common_name_check = true;
+        mqtt_cfg_.broker.verification.use_global_ca_store = false;
+        mqtt_cfg_.session.protocol_ver = MQTT_PROTOCOL_V_3_1_1;
+        mqtt_cfg_.credentials.client_id = client_id;
+#else
+        mqtt_cfg_.username = username;
+        mqtt_cfg_.password = password_str;
         mqtt_cfg_.uri = uri;
         mqtt_cfg_.cert_pem = tuya_cacert_pem;
         mqtt_cfg_.cert_len = sizeof(tuya_cacert_pem);
         mqtt_cfg_.skip_cert_common_name_check = true;
         mqtt_cfg_.use_global_ca_store = false;
-        // mqtt_cfg_.transport = MQTT_TRANSPORT_OVER_SSL;
         mqtt_cfg_.protocol_ver = MQTT_PROTOCOL_V_3_1_1;
-        static char client_id[50];
-        sprintf(client_id, "tuyalink_%s", device_id_);
         mqtt_cfg_.client_id = client_id;
+#endif
+
         client_ = esp_mqtt_client_init(&mqtt_cfg_);
 
         if (client_) {

--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: tuya-iot-example
+  friendly_name: Tuya IoT Example
+
+external_components:
+  - source:
+      type: local
+      path: components
+    components: [tuya_iot]
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+logger:
+api:
+
+wifi:
+  ssid: "YOUR_WIFI_SSID"
+  password: "YOUR_WIFI_PASSWORD"
+  ap:
+    ssid: "Tuya-IoT-Example Fallback"
+    password: "12345678"
+
+captive_portal:
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+tuya_iot:
+  id: tuya_iot_component
+  time_id: homeassistant_time
+  product_id: "YOUR_PRODUCT_ID"
+  device_id: "YOUR_DEVICE_ID"
+  device_secret: "YOUR_DEVICE_SECRET"
+  region: eu
+  on_event:
+    - event_name: property/set
+      then:
+        - logger.log:
+            format: "Tuya event received"

--- a/example.yaml
+++ b/example.yaml
@@ -1,6 +1,6 @@
 esphome:
   name: tuya-iot-example
-  friendly_name: Tuya IoT Example
+  friendly_name: tuya-iot-example
 
 external_components:
   - source:
@@ -9,19 +9,28 @@ external_components:
     components: [tuya_iot]
 
 esp32:
-  board: esp32dev
+  board: esp32-s3-devkitc-1
   framework:
-    type: arduino
+    type: esp-idf
 
+# Enable logging
 logger:
+
+# Enable Home Assistant API
 api:
+
+ota:
+  - platform: esphome
+    password: "YOUR_OTA_PASSWORD"
 
 wifi:
   ssid: "YOUR_WIFI_SSID"
   password: "YOUR_WIFI_PASSWORD"
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    ssid: "Tuya-IoT-Example Fallback"
-    password: "12345678"
+    ssid: "Tuya-Test Fallback Hotspot"
+    password: "YOUR_AP_PASSWORD"
 
 captive_portal:
 
@@ -29,15 +38,107 @@ time:
   - platform: homeassistant
     id: homeassistant_time
 
+switch:
+  - platform: gpio
+    pin: 1
+    name: "switch test 1"
+    id: switch_test_1
+    on_turn_on:
+      - lambda: !lambda |-
+          id(tuya_iot_component).property_report("output1", true);
+    on_turn_off:
+      - lambda: !lambda |-
+          id(tuya_iot_component).property_report("output1", false);
+  - platform: gpio
+    pin: 2
+    name: "switch test 2"
+    id: switch_test_2
+    on_turn_on:
+      - lambda: !lambda |-
+          id(tuya_iot_component).property_report("output2", true);
+    on_turn_off:
+      - lambda: !lambda |-
+          id(tuya_iot_component).property_report("output2", false);
+
 tuya_iot:
   id: tuya_iot_component
-  time_id: homeassistant_time
   product_id: "YOUR_PRODUCT_ID"
   device_id: "YOUR_DEVICE_ID"
   device_secret: "YOUR_DEVICE_SECRET"
-  region: eu
+  region: eu # eu, us, eus, weu, in, cn
+  # eu: Central Europe Data Center
+  # us: US West Data Center
+  # eus: US East Data Center
+  # weu: Western Europe Data Center
+  # in: India Data Center
+  # cn: Chinese Data Center
+
   on_event:
     - event_name: property/set
       then:
-        - logger.log:
-            format: "Tuya event received"
+        - lambda: !lambda |-
+              // Append the required switch in switch_map to respond to commands issued by Tuya.
+              static std::map<float, switch_::Switch*> switch_map {
+                { 1, id(switch_test_1) },
+                { 2, id(switch_test_2) },
+              };
+
+              bool is_target_output = false;
+              bool output_state = false;
+              int output_number = 0;
+              // Modify this number 2 to match the number of switches in the above switch_map.
+              for (int i = 1; i <= 2; i++) {
+                std::string key = "output" + std::to_string(i);
+                if (x["data"][key].is<bool>()) {
+                  is_target_output = true;
+                  output_state = x["data"][key].as<bool>();
+                  output_number = i;
+                  break;
+                }
+              }
+
+              if (is_target_output) {
+                auto iterator = switch_map.find(output_number);
+                if (iterator != switch_map.end()) {
+                  auto sw = iterator->second;
+                  if (output_state) {
+                    sw->turn_on();
+                  } else {
+                    sw->turn_off();
+                  }
+                }
+              }
+
+              bool is_target_all_on = false;
+              bool all_on_state = false;
+
+              if (x["data"]["all_on"].is<bool>()) {
+                is_target_all_on = true;
+                all_on_state = x["data"]["all_on"].as<bool>();
+              }
+
+              if (is_target_all_on) {
+                if (all_on_state) {
+                  for(const auto& pair : switch_map) {
+                    auto sw = pair.second;
+                    sw->turn_on();
+                  }
+                }
+              }
+
+              bool is_target_all_off = false;
+              bool all_off_state = false;
+
+              if (x["data"]["all_off"].is<bool>()) {
+                is_target_all_off = true;
+                all_off_state = x["data"]["all_off"].as<bool>();
+              }
+
+              if (is_target_all_off) {
+                if (all_off_state) {
+                  for(const auto& pair : switch_map) {
+                    auto sw = pair.second;
+                    sw->turn_off();
+                  }
+                }
+              }


### PR DESCRIPTION
Summary
- ensure Tuya component keeps MQTT enabled on ESP32 and switches SHA256 implementation to mbedTLS for HMAC credentials
- update MQTT setup to populate new fields across IDF versions and tighten static buffers to avoid dynamic allocation
- extend gitignore for build artifacts/venvs and add a sample `example.yaml` illustrating Tuya configuration

Testing
- Not run (not requested)